### PR TITLE
Return empty set when grouping an empty set

### DIFF
--- a/src/main/java/ch/geowerkstatt/ilivalidator/extensions/functions/GetInGroupsIoxPlugin.java
+++ b/src/main/java/ch/geowerkstatt/ilivalidator/extensions/functions/GetInGroupsIoxPlugin.java
@@ -30,6 +30,10 @@ public final class GetInGroupsIoxPlugin extends BaseInterlisFunction {
             return Value.createUndefined();
         }
 
+        if (inputObjects.isEmpty()) {
+            return new Value(Collections.emptyList());
+        }
+
         Viewable contextClass = EvaluationHelper.getContextClass(td, contextObject, argObjects);
         if (contextClass == null) {
             throw new IllegalStateException("unknown class in " + usageScope);

--- a/src/test/data/GetInGroups/SetConstraintEmpty.ili
+++ b/src/test/data/GetInGroups/SetConstraintEmpty.ili
@@ -1,0 +1,17 @@
+INTERLIS 2.4;
+
+MODEL TestSuite
+  AT "mailto:info@geowerkstatt.ch" VERSION "2024-01-09" =
+  IMPORTS GeoW_FunctionsExt;
+
+  TOPIC FunctionTestTopic =
+
+    CLASS BaseClass =
+        textAttr: TEXT*16;
+        SET CONSTRAINT trueConstraintTextAttr: INTERLIS.elementCount(GeoW_FunctionsExt.GetInGroups(ALL, "textAttr")) == 0;
+        SET CONSTRAINT falseConstraintTextAttr: INTERLIS.elementCount(GeoW_FunctionsExt.GetInGroups(ALL, "textAttr")) == 2;
+    END BaseClass;
+
+  END FunctionTestTopic;
+
+END TestSuite.

--- a/src/test/data/GetInGroups/TestDataEmpty.xtf
+++ b/src/test/data/GetInGroups/TestDataEmpty.xtf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ili:transfer xmlns:ili="http://www.interlis.ch/xtf/2.4/INTERLIS" xmlns:geom="http://www.interlis.ch/geometry/1.0"
+              xmlns:TestSuite="http://www.interlis.ch/xtf/2.4/TestSuite">
+    <ili:headersection>
+        <ili:models>
+            <ili:model>GeoW_FunctionsExt</ili:model>
+            <ili:model>TestSuite</ili:model>
+        </ili:models>
+        <ili:sender>ili2gpkg-4.6.1-63db90def1260a503f0f2d4cb846686cd4851184</ili:sender>
+    </ili:headersection>
+    <ili:datasection>
+        <TestSuite:FunctionTestTopic ili:bid="TestSuite.FunctionTestTopic">
+        </TestSuite:FunctionTestTopic>
+    </ili:datasection>
+</ili:transfer>

--- a/src/test/java/ch/geowerkstatt/ilivalidator/extensions/functions/GetInGroupsIoxPluginTest.java
+++ b/src/test/java/ch/geowerkstatt/ilivalidator/extensions/functions/GetInGroupsIoxPluginTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 class GetInGroupsIoxPluginTest {
 
     protected static final String TEST_DATA = "GetInGroups/TestData.xtf";
+    protected static final String TEST_DATA_EMPTY = "GetInGroups/TestDataEmpty.xtf";
     ValidationTestHelper vh = null;
 
     @BeforeEach
@@ -27,5 +28,13 @@ class GetInGroupsIoxPluginTest {
         AssertionHelper.assertSingleConstraintError(vh, 0, "falseConstraintTextAttr");
         AssertionHelper.assertSingleConstraintError(vh, 0, "falseConstraintEnumAttr");
         AssertionHelper.assertSingleConstraintError(vh, 0, "falseConstraintNumberAttr");
+    }
+
+    @Test
+    void emptySet() throws Ili2cFailure, IoxException {
+        vh.runValidation(new String[]{TEST_DATA_EMPTY}, new String[]{"GetInGroups/SetConstraintEmpty.ili"});
+        Assert.equals(1, vh.getErrs().size());
+        AssertionHelper.assertNoConstraintError(vh, "trueConstraintTextAttr");
+        AssertionHelper.assertConstraintErrors(vh, 1, "falseConstraintTextAttr");
     }
 }


### PR DESCRIPTION
Using GetInGroups in the SET CONSTRAINT of an empty set previously resulted in `Error: unknown class in <constraint name>`.